### PR TITLE
Integrate aTLS

### DIFF
--- a/python-package-prompt-guard/src/promptguard/configuration.py
+++ b/python-package-prompt-guard/src/promptguard/configuration.py
@@ -1,0 +1,40 @@
+"""
+This module handles configuration logic for the promptguard package.
+"""
+import os
+from typing import Tuple
+
+# TODO: Once we have deployed the Promptguard Service this should be hardcoded
+# to use that domain, as end users shouldn't need to configure the
+# domain name manually.
+SERVER_HOSTNAME_ENV_VAR = "PROMPTGUARD_SERVER_HOSTNAME"
+SERVER_PORT_ENV_VAR = "PROMPTGUARD_SERVER_PORT"
+
+DEFAULT_SERVER_PORT = 443
+
+
+def get_server_config() -> Tuple[str, int]:
+    """
+    Retrieve from the environment the hostname or IP address and the port
+    number of the PromptGuard service to use. If the corresponding environment
+    variables are not set, defaults will be returned.
+
+    Returns
+    -------
+    (str, int)
+        The hostname or IP and the port number to use
+    """
+    hostname = os.environ.get(SERVER_HOSTNAME_ENV_VAR)
+    if not hostname:
+        raise Exception(
+            f"Unable to read the PromptGuard server hostname, \
+            ensure the {SERVER_HOSTNAME_ENV_VAR} environment variable is set."
+        )
+
+    port_str = os.environ.get(SERVER_PORT_ENV_VAR)
+    if port_str is not None:
+        port = int(port_str)
+    else:
+        port = DEFAULT_SERVER_PORT
+
+    return (hostname, port)

--- a/python-package-prompt-guard/src/promptguard/promptguard_service.py
+++ b/python-package-prompt-guard/src/promptguard/promptguard_service.py
@@ -2,19 +2,15 @@
 This module exposes wrappers around API calls to the PromptGuard service.
 """
 import json
-import os
 from dataclasses import dataclass
 from http import HTTPStatus
+from http.client import HTTPException
 from typing import Dict, List, Union
 
 from promptguard.authentication import get_api_key
+from promptguard.configuration import get_server_config
 from pyatls import AttestedHTTPSConnection, AttestedTLSContext
 from pyatls.validators import AZ_AAS_GLOBAL_JKUS, AzAasAciValidator, Validator
-
-# TODO: Once we have deployed the Promptguard Service this should be hardcoded
-# to use that domain, as end users shouldn't need to configure the
-# domain name manually.
-SERVICE_DOMAIN_NAME_ENV_VAR = "PROMPTGUARD_SERVICE_DOMAIN_NAME"
 
 
 @dataclass
@@ -39,8 +35,8 @@ def sanitize(text: str) -> SanitizeResponse:
         The anonymzied version of text without PII and
         a secret entropy value.
     """
-    response = _send_request_to_ppp_service(
-        endpoint="sanitize", payload={"text": text}
+    response = _send_request_to_promptguard_service(
+        endpoint="/sanitize", payload={"text": text}
     )
     return SanitizeResponse(**json.loads(response))
 
@@ -70,8 +66,8 @@ def desanitize(
     DesanitizeResponse
         The deanonymzied version of `sanitized_text` with PII added back in.
     """
-    response = _send_request_to_ppp_service(
-        endpoint="desanitize",
+    response = _send_request_to_promptguard_service(
+        endpoint="/desanitize",
         payload={
             "sanitized_text": sanitized_text,
             "secure_context": secure_context,
@@ -83,7 +79,7 @@ def desanitize(
 ########## Helper Functions ##########
 
 
-def _send_request_to_ppp_service(
+def _send_request_to_promptguard_service(
     endpoint: str, payload: Dict[str, Union[str, bytes]]
 ) -> str:
     """
@@ -105,25 +101,21 @@ def _send_request_to_ppp_service(
         The response body returned by the request, only returned
         if the request was successful
     """
-    service_domain_name = os.environ.get(SERVICE_DOMAIN_NAME_ENV_VAR)
-    if not service_domain_name:
-        raise Exception(
-            f"Unable to get PromptGuard service domain name, ensure \
-            the {SERVICE_DOMAIN_NAME_ENV_VAR} environment variable is set."
-        )
 
-    endpoint_url = f"http://{service_domain_name}/{endpoint}"
     api_key = get_api_key()
+    hostname, port = get_server_config()
 
     ctx = AttestedTLSContext(_get_default_validators())
-    conn = AttestedHTTPSConnection(service_domain_name, ctx, port=80)
+    conn = AttestedHTTPSConnection(hostname, ctx, port)
+
+    headers = {"Authorization": f"Bearer {api_key}"}
 
     try:
         conn.request(
             "POST",
-            f"/{endpoint}",
+            endpoint,
             json.dumps(payload),
-            headers={"Authorization": f"Bearer {api_key}"},
+            headers,
         )
 
         response = conn.getresponse()
@@ -133,8 +125,8 @@ def _send_request_to_ppp_service(
         response_text = response_body.decode()
 
         if response_code != HTTPStatus.OK:
-            raise Exception(
-                f"Error response from {endpoint_url}: "
+            raise HTTPException(
+                f"Error response from the PromptGuard server: "
                 f"[HTTP {response_code}] {response_text}"
             )
 
@@ -144,6 +136,15 @@ def _send_request_to_ppp_service(
 
 
 def _get_default_validators() -> List[Validator]:
+    """
+    Retrieve a list of default aTLS validators to use when connecting to the
+    PromptGuard server with sane default configurations.
+
+    Returns
+    -------
+    list of Validator
+        One or more aTLS validators
+    """
     az_aas_aci_validator = AzAasAciValidator(jkus=AZ_AAS_GLOBAL_JKUS)
 
     return [az_aas_aci_validator]


### PR DESCRIPTION
# Overview

This PR integrates aTLS into the PromptGuard Python client.

### !! Update !!
After discussing this with Zizhong and Octavian, all surfacing of the aTLS configuration to the users of this package has been removed. The package picks some sane defaults only for now.

----

The `sanitize` and `desanitize` functions are augmented with an additional, optional parameter:

```python
validators : Optional[List[Validator]]
```

where `Validator` is a class in the aTLS Python package.

A `Validator` knows how to appraise attestation documents, which could contain evidence from the attester (e.g. an AMD SEV-SNP CVM) or an attestation result from a verifier (e.g., AAS). Attestation documents are issued by the implementors of the `Issuer` interface in the Go aTLS package. The aTLS Python package currently implements a single `Validator` for confidential Azure ACI container instances, `AzAasAciValidator`.

This validator can be parameterized with:

1. A list of allowed Confidential Computing Enforcement (CCE) policies
2. A list of allowed JKU URLs

## CCE Policies

When we deploy PromptGuard to ACI, we specify a CCE policy. This policy carries information about which container images are allowed to run (e.g., image hashes), whether `kubectl exec` is allowed, and various other runtime settings. The contents of the CCE policy affect the security posture of the service and should thus be appraised during attestation.

The CCE policy is included in the AMD SEV-SNP report created by PromptGuard. More specifically, the policy is passed into the Utility VM (UVM) that hosts any one instance of the containerized PromptGuard service via SEV-SNP's Host Data field during VM launch. The hash of the policy is in turn included in the report, by virtue of which it is possible to bind a given CCE policy to a given instance of PromptGuard.

There are two primary ways of appraising the CCE policy in effect for a given ACI instance:

1. Using a custom AAS instance and a custom AAS attestation policy
2. Specifying known-good policies at the client

### Custom AAS Instance

This requires creating and hosting our own AAS instance on our Azure subscription and constructing a custom AAS policy that looks at the value of the host data hash in SEV-SNP reports and compares that against a list of known-good policies.

### Client-side appraisal

This requires that the aTLS Python package and/or the PromptGuard Python package and/or higher layers of the stack expose functionality to pass in known-good policies during attestation. In other words, the relying party (i.e., the user of the service) must know which CCE policies are good.

### Pros and Cons

**Custom AAS Instance**
\+ We can update the list of known-good policies at any time in a manner transparent to users
\- Requires us to host one or more AAS instances and keep the attestation policy up-to-date
\- These custom AAS instances would be opaque to the user and they would be unable to inspect the AAS policy

**Client-side Appraisal**
\+ User need only trust default public instances of AAS
\- We must either embed known-good CCE policies or hashes thereof in our client-side Python packages or publish them for our users to use

### Future Work
Ideally, we would not use AAS at all to remove Azure from the TCB as much as possible. As a result, the usage of custom AAS instances would be rendered moot.

Additionally, the current attestation model follows the IETF RaTS' Passport model. That is, the PromptGuard service sends to the Relying Party (i.e., the user) an AAS-issued JWT token that supposedly proves its trustworthiness. Instead, we could use the Background Check model. In that model, the service would send to the Relying Party the entirety of its evidence and let the Relying Party decide how to appraise it. At that point, the Relying Party can either use a publicly-available default AAS instance, their own custom instance(s), perhaps with a custom AAS policy, or perform the role of the Verifier and appraise the evidence directly. In this sense, using the Background Check model is more flexible and renders our usage of custom AAS instances unnecessary.

## JKUs

The AAS-issued JWT token that the PromptGuard service submits to the client carries a JKU claim. This claim is the URL of the JWKS server that contains the key against which the user must verify the signature, and thus the validity, of the JWT token. Since the JKU is read prior to token validation, it is best to ensure that it points to a known-good JWKS server. As a result, the user may parameterize the `AzAasAciValidator` with a list of known AAS JWKS URLs. By default, this list contains the URLs of all publicly available AAS instances.

# Future Work

It would be good to:

1. Coalesce around the long-term end-to-end attestation story for PromptGuard. For example, do we use the Background Check model or the Passport model? Do we continue to use AAS, do we perform evidence appraisal manually (i.e., we write a RaTS Verifier), do we offer both?

2. When using AAS, beyond merely verifying the JWT token, we should also check AAS' SGX quote using Open Enclave and verify the binding of the JWT signing key against its hash in the quote to ascertain that the instance of AAS that issued the token is legitimate.