### PR TITLE
docs: add readthedocs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PromptGuard
-PromptGuard enables applications to leverage the power of language models without compromising user privacy. This repo contains the PromptGuard Python library, which provides a simple interface for interacting with the PromptGuard API. More information about PromptGuard can be found in the [documentation]().
+PromptGuard enables applications to leverage the power of language models without compromising user privacy. This repo contains the PromptGuard Python library, which provides a simple interface for interacting with the PromptGuard API. More information about PromptGuard can be found in the [documentation](https://promptguard.readthedocs.io/).
 
 ## Installation
 
@@ -10,4 +10,4 @@ pip install promptguard
 ```
 
 ## Documentation
-For a quickstart, technical overview, and API reference, see the [PromptGuard documentation]().
+For a quickstart, technical overview, and API reference, see the [PromptGuard documentation](https://promptguard.readthedocs.io/).

--- a/docs/reference/library_api.md
+++ b/docs/reference/library_api.md
@@ -1,3 +1,5 @@
 # PromptGuard Library API reference
 
 ::: python-package-prompt-guard.src.promptguard.promptguard_service
+    options:
+        show_if_no_docstring: true

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,4 +1,5 @@
 composability
+docstring
 LangChain
 LLM
 octicons

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
 ---
 site_name: PromptGuard
-site_url: http://docs.promptguard.opaque.co
+site_url: https://promptguard.readthedocs.io/
+repo_url: https://github.com/opaque-systems/promptguard-python/
+repo_name: opaque-systems/promptguard-python
 copyright: >
   Copyright &copy; <a href="https://opaque.co/">Opaque Systems</a> 2023
 theme:


### PR DESCRIPTION
I just set up [a public readthedocs site](https://promptguard.readthedocs.io/en/latest/) that will host the documentation for this repository. This change links to this site in the README.

Also makes a small change to the `mkdocs` configuration to enable a material + mkdocs feature that has every documentation page point to the repo.

<img width="246" alt="image" src="https://github.com/opaque-systems/promptguard-python/assets/18539530/1f50d040-29e3-4ee6-806c-18f607f25cb3">

Lastly, we also add the dataclasses `SanitizeResponse` and `DesanitizeResponse` to the API reference.
