### PR TITLE
atls: use atls instead of pyatls

### DIFF
--- a/python-package-prompt-guard/src/promptguard/promptguard_service.py
+++ b/python-package-prompt-guard/src/promptguard/promptguard_service.py
@@ -7,10 +7,10 @@ from http import HTTPStatus
 from http.client import HTTPException
 from typing import Dict, List, Union
 
+from atls import AttestedHTTPSConnection, AttestedTLSContext
+from atls.validators import AZ_AAS_GLOBAL_JKUS, AzAasAciValidator, Validator
 from promptguard.authentication import get_api_key
 from promptguard.configuration import get_server_config
-from pyatls import AttestedHTTPSConnection, AttestedTLSContext
-from pyatls.validators import AZ_AAS_GLOBAL_JKUS, AzAasAciValidator, Validator
 
 
 @dataclass


### PR DESCRIPTION
# Overview

If [the corresponding PR into `atls-python`](https://github.com/opaque-systems/atls-python/pull/6) goes through, adopt the new naming in this package, too.