### PR TITLE
docs: rename site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 ---
-site_name: PromptGuard
+site_name: Opaque PromptGuard
 site_url: https://promptguard.readthedocs.io/
 repo_url: https://github.com/opaque-systems/promptguard-python/
 repo_name: opaque-systems/promptguard-python


### PR DESCRIPTION
Rename the documentation site for clearer branding