### PR TITLE
docs: rename promptguard to opaqueprompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# PromptGuard
-PromptGuard enables applications to leverage the power of language models while preserving user privacy. This repo contains the PromptGuard Python library, which provides a simple interface for interacting with the PromptGuard Service. More information about PromptGuard can be found in the [documentation](https://promptguard.readthedocs.io/).
+# OpaquePrompts
+OpaquePrompts enables applications to leverage the power of language models while preserving user privacy. This repo contains the OpaquePrompts Python library, which provides a simple interface for interacting with the OpaquePrompts Service. More information about OpaquePrompts can be found in the [documentation](https://opaqueprompts.readthedocs.io/).
 
 **API Stability:** This package is still in development. As such, its API may
 change until it is sufficiently mature.
 
 ## Installation
 
-The PromptGuard Python library can be installed via pip:
+The OpaquePrompts Python library can be installed via pip:
 
 ```bash
-pip install promptguard
+pip install opaqueprompts
 ```
 
 ## Documentation
-For a quickstart, technical overview, and API reference, see the [PromptGuard documentation](https://promptguard.readthedocs.io/).
+For a quickstart, technical overview, and API reference, see the [OpaquePrompts documentation](https://opaqueprompts.readthedocs.io/).

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,29 +1,29 @@
 # Quickstart
 
 ## Installation
-To install PromptGuard, run:
+To install OpaquePrompts, run:
 
 ```bash
-pip install promptguard
+pip install opaqueprompts
 ```
 
 ## Environment Setup
-Accessing the PromptGuard API requires an API key, which you can get by creating an account [on the PromptGuard website](https://promptguard.opaque.co). Once you have an account, you can find your API key on the [API Keys page](https://promptguard.opaque.co/api-keys).
+Accessing the OpaquePrompts API requires an API key, which you can get by creating an account [on the OpaquePrompts website](https://opaqueprompts.opaque.co). Once you have an account, you can find your API key on the [API Keys page](https://opaqueprompts.opaque.co/api-keys).
 
 Once you have your key, set it as an environment variable:
 
 ```bash
-export PROMPTGUARD_API_KEY="..."
+export OPAQUEPROMPTS_API_KEY="..."
 ```
 
-## Using PromptGuard standalone
-PromptGuard offers two main functions: `sanitize()` and `desanitize()`. `sanitize()` takes a string and returns a sanitized (i.e. encrypted and redacted) version of it, while `desanitize()` takes a sanitized string and returns the original string.
+## Using OpaquePrompts standalone
+OpaquePrompts offers two main functions: `sanitize()` and `desanitize()`. `sanitize()` takes a string and returns a sanitized (i.e. encrypted and redacted) version of it, while `desanitize()` takes a sanitized string and returns the original string.
 
 ```python
-import promptguard as pg
+import opaqueprompts
 
 input_text_with_pii = "John Smith called 213-456-7098 (the phone number of his friend Sarah Jane) and asked her to meet him in San Francisco."
-sanitized_response = pg.sanitize(text = input_text_with_pii)
+sanitized_response = opaqueprompts.sanitize(text = input_text_with_pii)
 ```
 The `sanitized_response` contains both the `sanitized_text` as well as `secure_context` which must be passed to the followup call to `desanitize()`. 
 
@@ -38,7 +38,7 @@ which should get passed to the desanitize call as shown below.
 # Assume that sanitized_response.sanitized_text was passed into an LLM of your
 # choice, and the final output is saved to 'llm_output" such that
 # llm_output = "PERSON_1 and PERSON_2 will be meeting in LOCATION_1"
-desanitized_response = pg.desanitize(sanitized_text = llm_output, secure_context = sanitized_response.secure_context)
+desanitized_response = opaqueprompts.desanitize(sanitized_text = llm_output, secure_context = sanitized_response.secure_context)
 ```
 
 The `desanitized_response` contains only one field `desanitized_text` which contains the desanitized version of `llm_output`.
@@ -48,8 +48,6 @@ The `desanitized_response` contains only one field `desanitized_text` which cont
 DesanitizeResponse(desanitized_text='Sarah Jane and John Smith will be meeting in San Francisco')
 ```
 
-## Using PromptGuard with LangChain
+## Using OpaquePrompts with LangChain
 
-TODO: add link to LangChain docs
-
-PromptGuard offers a [LangChain](https://python.langchain.com/docs/get_started/introduction.html) integration, enabling you to easily build privacy-preserving LLM applications.
+OpaquePrompts offers a [LangChain](https://python.langchain.com/docs/get_started/introduction.html) integration, enabling you to easily build privacy-preserving LLM applications. See the [OpaquePrompts page in the LangChain documentation](https://python.langchain.com/docs/integrations/llms/promptguard) for more.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ hide:
 ---
 
 # Introduction
-PromptGuard is a service that enables applications to leverage the power of language models without compromising user privacy. Designed for composability and ease of integration into existing applications and services, PromptGuard is consumable via a simple Python library as well as through [LangChain](https://python.langchain.com/docs/get_started/introduction.html). Perhaps more importantly, PromptGuard leverages the power of [confidential computing](https://en.wikipedia.org/wiki/Confidential_computing) to ensure that even the PromptGuard service itself cannot access the data it is protecting.
+OpaquePrompts is a service that enables applications to leverage the power of language models without compromising user privacy. Designed for composability and ease of integration into existing applications and services, OpaquePrompts is consumable via a simple Python library as well as through [LangChain](https://python.langchain.com/docs/get_started/introduction.html). Perhaps more importantly, OpaquePrompts leverages the power of [confidential computing](https://en.wikipedia.org/wiki/Confidential_computing) to ensure that even the OpaquePrompts service itself cannot access the data it is protecting.
 
-Today's LLM application architectures often yield constructed prompts that may include retrieved context, conversation memory, and/or a user query, all of which may contain sensitive information. PromptGuard enables applications to protect this sensitive information by sanitizing prompts before they're sent to a language model. PromptGuard can then "de-sanitize" the model's response, ensuring that the application receives the same response it would have received had the prompt not been sanitized. You can think of PromptGuard as a privacy layer that wraps a language model, transparently sanitizing and de-sanitizing prompts and responses.
+Today's LLM application architectures often yield constructed prompts that may include retrieved context, conversation memory, and/or a user query, all of which may contain sensitive information. OpaquePrompts enables applications to protect this sensitive information by sanitizing prompts before they're sent to a language model. OpaquePrompts can then "de-sanitize" the model's response, ensuring that the application receives the same response it would have received had the prompt not been sanitized. You can think of OpaquePrompts as a privacy layer that wraps a language model, transparently sanitizing and de-sanitizing prompts and responses.
 
 <div class="grid cards" markdown>
 
@@ -15,7 +15,7 @@ Today's LLM application architectures often yield constructed prompts that may i
 
     ---
 
-    New to PromptGuard? Quickly get started here.
+    New to OpaquePrompts? Quickly get started here.
     
     [Learn more :octicons-arrow-right-24:](getting_started/quickstart.md){: .right}
 
@@ -23,7 +23,7 @@ Today's LLM application architectures often yield constructed prompts that may i
 
     ---
 
-    Gain a better understanding of how PromptGuard protects sensitive data without seeing it.
+    Gain a better understanding of how OpaquePrompts protects sensitive data without seeing it.
 
     [Learn more :octicons-arrow-right-24:](getting_started/overview.md){: .right}
 
@@ -31,11 +31,11 @@ Today's LLM application architectures often yield constructed prompts that may i
 
     ---
 
-    See the API reference for the PromptGuard Python library.
+    See the API reference for the OpaquePrompts Python library.
 
     [Learn more :octicons-arrow-right-24:](reference/library_api.md){: .right}
 
 </div>
 
 ## Get help
-Can't find what you're looking for? Contact us at [promptguard@opaque.co](mailto:promptguard@opaque.co).
+Can't find what you're looking for? Contact us at [opaqueprompts@opaque.co](mailto:opaqueprompts@opaque.co).

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -10,9 +10,9 @@ ITINs
 LangChain
 LLM
 octicons
+OpaquePrompts
+opaqueprompts
 PII
-PromptGuard
-promptguard
 quickstart
 src
 SSN

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -13,6 +13,8 @@ octicons
 OpaquePrompts
 opaqueprompts
 PII
+PromptGuard
+promptguard
 quickstart
 src
 SSN

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 ---
-site_name: Opaque PromptGuard
-site_url: https://promptguard.readthedocs.io/
-repo_url: https://github.com/opaque-systems/promptguard-python/
-repo_name: opaque-systems/promptguard-python
+site_name: OpaquePrompts
+site_url: https://opaqueprompts.readthedocs.io/
+repo_url: https://github.com/opaque-systems/opaqueprompts-python/
+repo_name: opaque-systems/opaqueprompts-python
 copyright: >
   Copyright &copy; <a href="https://opaque.co/">Opaque Systems</a> 2023
 theme:
@@ -77,8 +77,8 @@ extra:
   analytics:
     provider: custom
   platform: Opaque
-  url: opaque-systems/promptguard-python
-  repo: promptguard-python
+  url: opaque-systems/opaqueprompts-python
+  repo: opaqueprompts-python
   version: 0.1.0 # Adjust for each new release.
 
 nav:

--- a/python-package/README.md
+++ b/python-package/README.md
@@ -1,16 +1,16 @@
-# PromptGuard
-PromptGuard enables applications to leverage the power of language models while preserving user privacy. This repo contains the PromptGuard Python library, which provides a simple interface for interacting with the PromptGuard Service. More information about PromptGuard can be found in the [documentation](https://promptguard.readthedocs.io/).
+# OpaquePrompts
+OpaquePrompts enables applications to leverage the power of language models while preserving user privacy. This repo contains the OpaquePrompts Python library, which provides a simple interface for interacting with the OpaquePrompts Service. More information about OpaquePrompts can be found in the [documentation](https://opaqueprompts.readthedocs.io/).
 
 **API Stability:** This package is still in development. As such, its API may
 change until it is sufficiently mature.
 
 ## Installation
 
-The PromptGuard Python library can be installed via pip:
+The OpaquePrompts Python library can be installed via pip:
 
 ```bash
-pip install promptguard
+pip install opaqueprompts
 ```
 
 ## Documentation
-For a quickstart, technical overview, and API reference, see the [PromptGuard documentation](https://promptguard.readthedocs.io/).
+For a quickstart, technical overview, and API reference, see the [OpaquePrompts documentation](https://opaqueprompts.readthedocs.io/).


### PR DESCRIPTION
* Rename PromptGuard to OpaquePrompts in text
* Renames the `promptguard` python package to `opaqueprompts`
* Adds a link to the LangChain integration