### PR TITLE
build: Use smaller mega-linter image

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -51,7 +51,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://oxsecurity.github.io/megalinter/flavors/
-        uses: oxsecurity/megalinter@v6
+        uses: oxsecurity/megalinter/flavors/cupcake@beta
         env:
           # All available variables are described in documentation
           # https://oxsecurity.github.io/megalinter/configuration/


### PR DESCRIPTION
Use a smaller mega linter image (1.4 GB vs 2.8 GB), called [cupcake](https://github.com/oxsecurity/megalinter/blob/main/docs/flavors/cupcake.md), that only has a subset of all linters installed. This reduces the image download by about 30 seconds.