### PR TITLE
Change OpaquePrompts to Opaque Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@
 [![](https://dcbadge.vercel.app/api/server/mVuCfxudrD?compact=true&style=flat)](https://discord.gg/mVuCfxudrD)
 [![PyPI version](https://badge.fury.io/py/opaqueprompts.svg)](https://badge.fury.io/py/opaqueprompts)
 
-OpaquePrompts enables applications to leverage the power of language models while preserving user privacy. This repo contains the OpaquePrompts Python library, which provides a simple interface for interacting with the OpaquePrompts Service. More information about OpaquePrompts can be found in the [documentation](https://opaqueprompts.readthedocs.io/).
+Opaque Gateway enables applications to leverage the power of language models while preserving user privacy. This repo contains the Opaque Gateway Python library, which provides a simple interface for interacting with the Opaque Gateway Service. More information about Opaque Gateway can be found in the [documentation](https://opaquegateway.readthedocs.io/).
 
 **API Stability:** This package is still in development. As such, its API may
 change until it is sufficiently mature.
 
 ## Installation
 
-The OpaquePrompts Python library can be installed via pip:
+The Opaque Gateway Python library can be installed via pip:
 
 ```bash
 pip install opaqueprompts
 ```
 
 ## Documentation
-For a quickstart, technical overview, and API reference, see the [OpaquePrompts documentation](https://opaqueprompts.readthedocs.io/).
+For a quickstart, technical overview, and API reference, see the [Opaque Gateway documentation](https://opaquegateway.readthedocs.io/).
 
 ## Contact
-To contact us, join our [Discord server](https://discord.gg/mVuCfxudrD) or email us at [opaqueprompts@opaque.co](mailto:opaqueprompts@opaque.co).
+To contact us, join our [Discord server](https://discord.gg/mVuCfxudrD) or email us at [opaquegateway@opaque.co](mailto:opaquegateway@opaque.co).

--- a/docs/getting_started/overview.md
+++ b/docs/getting_started/overview.md
@@ -1,12 +1,12 @@
 # Overview
 
-## Technical Overview
+## Technical overview
 
-A technical overview on how OpaquePrompts leverages [confidential computing](https://en.wikipedia.org/wiki/Confidential_computing) and [remote attestation](https://www.redhat.com/en/blog/attestation-confidential-computing) is coming soon.
+A technical overview on how Opaque Gateway leverages [confidential computing](https://en.wikipedia.org/wiki/Confidential_computing) and [remote attestation](https://www.redhat.com/en/blog/attestation-confidential-computing) is coming soon.
 
-## Supported Entities
+## Supported entities
 
-OpaquePrompts, for now, supports only the English language. Currently, the following entity types will be identified and sanitized:
+Opaque Gateway, for now, supports only the English language. The service identifies and sanitizes the following entity types:
 
 | **Type**                                                                                                                        | **Notes**                           |
 |---------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
@@ -24,5 +24,5 @@ OpaquePrompts, for now, supports only the English language. Currently, the follo
 | Names                                                                                                                           |                                     |
 | Passport numbers                                                                                                                | Supports US passports               |
 | Phone numbers                                                                                                                   |                                     |
-| Social security numbers (SSN)                                                                                                   | Supports US social security numbers |
+| Social security numbers (SSNs)                                                                                                  | Supports US SSNs                    |
 | URLs                                                                                                                            |                                     |

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -8,7 +8,7 @@ pip install opaqueprompts
 ```
 
 ## Environment setup
-Accessing the Opaque Gateway API requires an API key, which you can get by creating an account on the [OpaquePrompts](https://opaqueprompts.opaque.co) website. Once you have an account, you can find your API key on the [API Key](https://opaqueprompts.opaque.co/#/main/api/key) page.
+Accessing the Opaque Gateway API requires an API key, which you can get by creating an account on the [Opaque Gateway](https://opaquegateway.opaque.co) website. Once you have an account, you can find your API key on the [API Key](https://opaquegateway.opaque.co/#/main/api/key) page.
 
 Once you have your key, set it as an environment variable:
 

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,14 +1,14 @@
 # Quickstart
 
 ## Installation
-To install OpaquePrompts, run:
+To install Opaque Gateway, run:
 
 ```bash
 pip install opaqueprompts
 ```
 
-## Environment Setup
-Accessing the OpaquePrompts API requires an API key, which you can get by creating an account [on the OpaquePrompts website](https://opaqueprompts.opaque.co). Once you have an account, you can find your API key on the [API Keys page](https://opaqueprompts.opaque.co/#/main/api/key).
+## Environment setup
+Accessing the Opaque Gateway API requires an API key, which you can get by creating an account on the [OpaquePrompts](https://opaqueprompts.opaque.co) website. Once you have an account, you can find your API key on the [API Key](https://opaqueprompts.opaque.co/#/main/api/key) page.
 
 Once you have your key, set it as an environment variable:
 
@@ -16,8 +16,8 @@ Once you have your key, set it as an environment variable:
 export OPAQUEPROMPTS_API_KEY="..."
 ```
 
-## Using OpaquePrompts standalone
-OpaquePrompts offers two main functions: `sanitize()` and `desanitize()`. `sanitize()` takes a string and returns a sanitized (i.e. encrypted and redacted) version of it, while `desanitize()` takes a sanitized string and returns the original string.
+## Using Opaque Gateway standalone
+Opaque Gateway offers two main functions: `sanitize()` and `desanitize()`. The `sanitize()` function takes a string and returns a sanitized (in other words, encrypted and redacted) version of it, while the `desanitize()` function takes a sanitized string and returns the original string.
 
 ### Sanitization
 
@@ -27,14 +27,14 @@ import opaqueprompts
 input_text_with_pii = "John Smith called 213-456-7098 (the phone number of his friend Sarah Jane) and asked her to meet him in San Francisco."
 sanitized_response = opaqueprompts.sanitize(input_texts = [input_text_with_pii])
 ```
-The `sanitized_response` contains both the `sanitized_texts` as well as `secure_context` which must be passed to the followup call to `desanitize()`. 
+As shown below, `sanitized_response` contains both the `sanitized_texts` and `secure_context` fields, which must be passed to the followup call to `desanitize()`. 
 
 ```python
 > print(sanitized_response)
 SanitizeResponse(sanitized_texts=['PERSON_2 called PHONE_NUMBER_1 (the phone number of his friend PERSON_1) and asked her to meet him in LOCATION_1.'], secure_context='eyJzZWNyZXRfZW50cm9weSI6IjRocWZxb1VBUmJueWNYeU5JRjROa3VzNjdkSnZtY1ZPVFhYcnlPWDdmNzAxNVR4NVUraTM5c3VGRTJqS3oySjUzMkM4ckF6L0cyME5sWGloZ2hicWhzcFF6N2pVTUZIVVNvMVRGam1UU2tTcG5pR1Bob0s5RUR3N3JQZ2VkMklJNEhRTHh2dVZNUnJlY2h3WVhGbGhZYzhFOEI1VFJkWVl2Sm1QUG5Rbkp3WT0iLCJlbnRpdHlfbWFwIjp7IkxPQ0FUSU9OXzEiOiJibFpDVE1oMTR0OW1FQmZsejk5cWVlWVJSTjdyUzhkUTZRRVZOZHlKNkEwPSIsIlBFUlNPTl8xIjoiZDZiR3VjOEJVNUdPcG56cDJoV1FaUUIyaUtvRzA2U3dCdGlkSXo5WGxaUT0iLCJQRVJTT05fMiI6IkpKSyt6cmhtTENzWGVkTHhoNWxhTWFFSzlUVmw1bU55MkNGR3FZekRmZ3M9IiwiUEhPTkVfTlVNQkVSXzEiOiJhQU9GVmhoT0tqczVzT0Iwczh2dnZwNTBsVk9XcnNyODE3eEVVSnkrTzdRPSJ9fQ==')
 ```
-As you can see, the `sanitized_texts` field contains the initial message, but with the PII removed. The `secure_context` is just an opaque set of bytes
-which should get passed to the desanitize call as shown below.
+As you can see, the `sanitized_texts` field contains the initial message, but with the PII removed. The `secure_context` is just an opaque set of bytes,
+which should get passed to the `desanitize` call as shown below.
 
 ### Desanitization
 
@@ -45,20 +45,20 @@ which should get passed to the desanitize call as shown below.
 desanitized_response = opaqueprompts.desanitize(sanitized_text = llm_output, secure_context = sanitized_response.secure_context)
 ```
 
-The `desanitized_response` contains only one field `desanitized_text` which contains the desanitized version of `llm_output`.
+The `desanitized_response` contains only one field, `desanitized_text`, which contains the desanitized version of `llm_output`.
  
 ```python
 > print(desanitized_response)
 DesanitizeResponse(desanitized_text='Sarah Jane and John Smith will be meeting in San Francisco')
 ```
 
-## Using OpaquePrompts with LangChain
+## Using Opaque Gateway with LangChain
 
-OpaquePrompts offers a [LangChain](https://python.langchain.com/docs/get_started/introduction.html) integration, enabling you to easily build privacy-preserving LLM applications. See the [OpaquePrompts page in the LangChain documentation](https://python.langchain.com/docs/integrations/llms/opaqueprompts) for more.
+Opaque Gateway offers a [LangChain](https://python.langchain.com/docs/get_started/introduction.html) integration, enabling you to easily build privacy-preserving LLM applications. See the [OpaquePrompts page in the LangChain documentation](https://python.langchain.com/docs/integrations/llms/opaqueprompts) for more information.
 
 ## Troubleshooting
 
-### Version Mismatch
+### Version mismatch
 
 We may make breaking changes and drop support for old versions of the Python package. If this happens, you should see an error message like this when making a `sanitize` or `desanitize` call:
 
@@ -68,7 +68,7 @@ Request sent using package version 0.1.0, but minimum supported version is 0.2.0
 
 If you see this, simply upgrade `opaqueprompts` with `pip install -U opaqueprompts` and then you should be able to continue using the package without issue.
 
-### Missing Version Header
+### Missing version header
 
 The logic to gracefully handle version mismatch was not added to the `opaqueprompts` package until version 0.1.0. As such, if you are using an older version of `opaqueprompts`, you may see the following error:
 
@@ -76,4 +76,4 @@ The logic to gracefully handle version mismatch was not added to the `opaqueprom
 Client-Version header not set, please ensure this request was sent using opaqueprompts version >= 0.1.0
 ```
 
-If you see this, make sure to update your `opaqueprompts` package to the latest version per the instructions in the "Version Mismatch" section.
+If you see this, make sure to update your `opaqueprompts` package to the latest version per the instructions in the previous section.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,4 +38,4 @@ Today's LLM application architectures often yield constructed prompts that may i
 </div>
 
 ## Get help
-Can't find what you're looking for? Contact us at [opaqueprompts@opaque.co](mailto:opaqueprompts@opaque.co).
+Can't find what you're looking for? Contact us at [opaquegateway@opaque.co](mailto:opaquegateway@opaque.co).

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ hide:
 ---
 
 # Introduction
-OpaquePrompts is a service that enables applications to leverage the power of language models without compromising user privacy. Designed for composability and ease of integration into existing applications and services, OpaquePrompts is consumable via [a simple Python library](https://opaqueprompts.readthedocs.io/en/latest/getting_started/quickstart/#installation) as well as through [LangChain](https://python.langchain.com/docs/integrations/llms/opaqueprompts). Perhaps more importantly, OpaquePrompts leverages the power of [confidential computing](https://en.wikipedia.org/wiki/Confidential_computing) to ensure that even the OpaquePrompts service itself cannot access the data it is protecting.
+Opaque Gateway is a service that enables applications to leverage the power of language models without compromising user privacy. Designed for composability and ease of integration into existing applications and services, Opaque Gateway is consumable via [a simple Python library](getting_started/quickstart.md#installation) as well as through [LangChain](https://python.langchain.com/docs/integrations/llms/opaqueprompts). Perhaps more importantly, Opaque Gateway leverages the power of [confidential computing](https://en.wikipedia.org/wiki/Confidential_computing) to ensure that even the Opaque Gateway service itself cannot access the data it is protecting.
 
-Today's LLM application architectures often yield constructed prompts that may include retrieved context, conversation memory, and/or a user query, all of which may contain sensitive information. OpaquePrompts enables applications to protect this sensitive information by sanitizing prompts before they're sent to a language model. OpaquePrompts can then "de-sanitize" the model's response, ensuring that the application receives the same response it would have received had the prompt not been sanitized. You can think of OpaquePrompts as a privacy layer that wraps a language model, transparently sanitizing and de-sanitizing prompts and responses.
+Today's LLM application architectures often yield constructed prompts that may include retrieved context, conversation memory, and/or a user query, all of which may contain sensitive information. Opaque Gateway enables applications to protect this sensitive information by sanitizing prompts before they're sent to a language model. Opaque Gateway can then "de-sanitize" the model's response, ensuring that the application receives the same response it would have received had the prompt not been sanitized. You can think of Opaque Gateway as a privacy layer that wraps a language model, transparently sanitizing and de-sanitizing prompts and responses.
 
 <div class="grid cards" markdown>
 
@@ -15,7 +15,7 @@ Today's LLM application architectures often yield constructed prompts that may i
 
     ---
 
-    New to OpaquePrompts? Quickly get started here.
+    New to Opaque Gateway? Quickly get started here.
     
     [Learn more :octicons-arrow-right-24:](getting_started/quickstart.md){: .right}
 
@@ -23,15 +23,15 @@ Today's LLM application architectures often yield constructed prompts that may i
 
     ---
 
-    Gain a better understanding of how OpaquePrompts protects sensitive data without seeing it.
+    Gain a better understanding of how Opaque Gateway protects sensitive data without seeing it.
 
     [Learn more :octicons-arrow-right-24:](getting_started/overview.md){: .right}
 
-*   :material-account: **API Reference**
+*   :material-code-tags: **API Reference**
 
     ---
 
-    See the API reference for the OpaquePrompts Python library.
+    See the API reference for the Opaque Gateway Python library.
 
     [Learn more :octicons-arrow-right-24:](reference/library_api.md){: .right}
 

--- a/docs/reference/library_api.md
+++ b/docs/reference/library_api.md
@@ -1,3 +1,3 @@
-# OpaquePrompts Library API reference
+# Opaque Gateway Library API reference
 
 ::: python-package.src.opaqueprompts.opaqueprompts_service

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -18,5 +18,6 @@ quickstart
 Sanitization
 src
 SSN
+SSNs
 toc
 TODO

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -11,6 +11,7 @@ ITINs
 LangChain
 LLM
 octicons
+opaquegateway
 OpaquePrompts
 opaqueprompts
 PII

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 ---
 site_name: Opaque Gateway
-site_url: https://opaqueprompts.readthedocs.io/
-repo_url: https://github.com/opaque-systems/opaqueprompts-python/
-repo_name: opaque-systems/opaqueprompts-python
+site_url: https://opaquegateway.readthedocs.io/
+repo_url: https://github.com/opaque-systems/opaquegateway-python/
+repo_name: opaque-systems/opaquegateway-python
 copyright: >
   Copyright &copy; <a href="https://opaque.co/">Opaque Systems</a> 2024
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 ---
-site_name: OpaquePrompts
+site_name: Opaque Gateway
 site_url: https://opaqueprompts.readthedocs.io/
 repo_url: https://github.com/opaque-systems/opaqueprompts-python/
 repo_name: opaque-systems/opaqueprompts-python
 copyright: >
-  Copyright &copy; <a href="https://opaque.co/">Opaque Systems</a> 2023
+  Copyright &copy; <a href="https://opaque.co/">Opaque Systems</a> 2024
 theme:
   name: material
   custom_dir: docs/overrides
@@ -46,7 +46,6 @@ plugins:
       zoomable: true
   - exclude:
       glob:
-        - api_reference/* # customer-facing docs
 extra_css:
   - css/extra.css
 extra_javascript:

--- a/python-package/src/opaqueprompts/authentication.py
+++ b/python-package/src/opaqueprompts/authentication.py
@@ -1,6 +1,7 @@
 """
 This module handles authentication logic for the opaqueprompts package.
 """
+
 import os
 
 API_KEY_ENV_VAR = "OPAQUEPROMPTS_API_KEY"

--- a/python-package/src/opaqueprompts/configuration.py
+++ b/python-package/src/opaqueprompts/configuration.py
@@ -1,6 +1,7 @@
 """
 This module handles configuration logic for the opaqueprompts package.
 """
+
 import os
 from typing import Tuple
 

--- a/python-package/src/opaqueprompts/opaqueprompts_service.py
+++ b/python-package/src/opaqueprompts/opaqueprompts_service.py
@@ -69,8 +69,8 @@ def sanitize(
     Returns
     -------
     SanitizeResponse
-        The anonymized version of `input_texts` without PII, and a secret entropy
-        value.
+        The anonymized version of `input_texts` without PII, and a secret
+        entropy value.
     """
     response = _send_request_to_opaqueprompts_service(
         endpoint="sanitize",

--- a/python-package/src/opaqueprompts/opaqueprompts_service.py
+++ b/python-package/src/opaqueprompts/opaqueprompts_service.py
@@ -1,5 +1,5 @@
 """
-This module exposes wrappers around API calls to the OpaquePrompts service.
+This module exposes wrappers around API calls to the Opaque Gateway service.
 """
 import json
 import os
@@ -69,7 +69,7 @@ def sanitize(
     Returns
     -------
     SanitizeResponse
-        The anonymized version of input_texts without PII and a secret entropy
+        The anonymized version of `input_texts` without PII, and a secret entropy
         value.
     """
     response = _send_request_to_opaqueprompts_service(
@@ -121,7 +121,7 @@ def desanitize(
     Returns
     -------
     DesanitizeResponse
-        The deanonymzied version of sanitized_text with PII added back in.
+        The de-anonymized version of `sanitized_text` with PII added back in.
     """
     response = _send_request_to_opaqueprompts_service(
         endpoint="desanitize",

--- a/python-package/src/opaqueprompts/opaqueprompts_service.py
+++ b/python-package/src/opaqueprompts/opaqueprompts_service.py
@@ -1,6 +1,7 @@
 """
 This module exposes wrappers around API calls to the Opaque Gateway service.
 """
+
 import json
 import os
 import threading


### PR DESCRIPTION
- Changed instances of _OpaquePrompts_ to _Opaque Gateway_
- Made minor edits for grammar and style

**Note:** Some references to OpaquePrompts still remain (in addition to the repo name and code):
   - Support email (opaqueprompts@opaque.co) on the [main page](https://opaqueprompts--44.org.readthedocs.build/en/44/#get-help)
   - Links to the OpaquePrompts website in the [Quickstart](https://opaqueprompts--44.org.readthedocs.build/en/44/getting_started/quickstart/#environment-setup)
   - Link to the OpaquePrompts page in the [LangChain](https://opaqueprompts--44.org.readthedocs.build/en/44/getting_started/quickstart/#using-opaque-gateway-with-langchain) documentation