### PR TITLE
version: atls: bump version and PyATLS dependency

### DIFF
--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opaqueprompts"
-version = "0.1.0"
+version = "0.1.1"
 description = "The client-side SDK for OpaquePrompts, a privacy layer that enables applications to wrap external provider calls with a sanitization mechanism that hides sensitive inputs via an attested trusted execution environment."
 readme = "README.md"
 authors= [{ name = "Opaque Systems", email = "pypi@opaque.co" }]

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 keywords = ["confidential", "llm", "ai", "generative", "security", "privacy"]
 dependencies = [
-    "pyatls >= 0.0.3",
+    "pyatls >= 0.0.5",
     "requests >= 2.0",
 ]
 


### PR DESCRIPTION
# Overview

The PyATLS package has received a bug fix for when JWT tokens appear to be issued in the future. This is due to clock drift between the issuing service and the machine verifying the token. The bug fix adds a 5s leeway to account for this, instead of attempting to be accurate to the millisecond.

This PR:
1. Bumps the underlying version of PyATLS to `0.0.5`;
2. Bumps the version of this package account for the change in dependency version.